### PR TITLE
chore(flux): enable wait+force in root Kustomization

### DIFF
--- a/flux-kustomization.yaml
+++ b/flux-kustomization.yaml
@@ -8,6 +8,8 @@ spec:
   interval: 5m
   path: ./      
   prune: true    
+  wait: true
+  force: true
   sourceRef:
     kind: GitRepository
     name: flux-system


### PR DESCRIPTION
Adds wait: true and force: true to the top-level Flux Kustomization for more reliable reconciliations.