### PR TITLE
chore(kustomize): include flux-torrus-dev in root kustomization

### DIFF
--- a/kustomization.yaml
+++ b/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - plex/plex-configmap.yaml
   - plex/plex-deployment.yaml
   - it-tools/it-tools-deployment.yaml
+  - flux-torrus-dev.yaml


### PR DESCRIPTION
Adds flux-torrus-dev.yaml to root kustomization resources for Flux to manage dev overlay.