### PR TITLE
fix(torrus): correct configMapRef casing in dev patch

### DIFF
--- a/apps/torrus/overlays/dev/patch-deployment.yaml
+++ b/apps/torrus/overlays/dev/patch-deployment.yaml
@@ -11,7 +11,7 @@ spec:
           imagePullPolicy: Always
           # (only dev pulls each time; prod will pin digests later)
           envFrom:
-            - configMapref:
+            - configMapRef:
                 name: torrus-config
             - secretRef:
                 name: torrus-secrets


### PR DESCRIPTION
Fixes the key to configMapRef in the dev Deployment patch so envFrom references the ConfigMap correctly.