### PR TITLE
chore(torrus): adjust readiness probe in base

### DIFF
--- a/apps/torrus/base/deployment.yaml
+++ b/apps/torrus/base/deployment.yaml
@@ -18,8 +18,10 @@ spec:
             - name: http
               containerPort: 9090
           readinessProbe:
-            httpGet: { path: /readyz, port: http }
-            initialDelaySeconds: 5
-          livenessProbe:
-            httpGet: { path: /healthz, port: http }
-            initialDelaySeconds: 10
+            httpGet:
+              path: /healthz
+              port: http
+            periodSeconds: 10
+            timeoutSeconds: 2
+            failureThreshold: 6
+          


### PR DESCRIPTION
Updates the base Deployment readiness probe to use /healthz with tuned timings; liveness handled elsewhere.