### PR TITLE
chore(torrus): include aria2 in dev kustomization

### DIFF
--- a/apps/torrus/overlays/dev/kustomization.yaml
+++ b/apps/torrus/overlays/dev/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   - namespace.yaml
   - configmap.yaml
   - secret.yaml
+  - aria2.yaml
 patchesStrategicMerge:
   - patch-deployment.yaml
   - patch-ingress.yaml


### PR DESCRIPTION
Adds aria2.yaml to the dev overlay kustomization resources list.