### PR TITLE
chore(torrus): point dev to in-cluster aria2 service

### DIFF
--- a/apps/torrus/overlays/dev/configmap.yaml
+++ b/apps/torrus/overlays/dev/configmap.yaml
@@ -5,7 +5,7 @@ metadata:
 data:
   TORRUS_CLIENT: "aria2"
   # For now (until aria2 runs in-cluster), keep local setting:
-  ARIA2_RPC_URL: "http://localhost:6800/jsonrpc"
+  ARIA2_RPC_URL: "http://aria2.torrus-dev.svc.cluster.local:6800/jsonrpc"
   ARIA2_TIMEOUT_MS: "5000"
   ARIA2_POLL_MS: "1000"
 


### PR DESCRIPTION
Update ARIA2_RPC_URL in dev ConfigMap to use the cluster Service DNS name.