### PR TITLE
chore(torrus): use Service short name for ARIA2_RPC_URL (dev)

### DIFF
--- a/apps/torrus/overlays/dev/configmap.yaml
+++ b/apps/torrus/overlays/dev/configmap.yaml
@@ -5,7 +5,7 @@ metadata:
 data:
   TORRUS_CLIENT: "aria2"
   # For now (until aria2 runs in-cluster), keep local setting:
-  ARIA2_RPC_URL: "http://aria2.torrus-dev.svc.cluster.local:6800/jsonrpc"
+  ARIA2_RPC_URL: "http://aria2:6800/jsonrpc"
   ARIA2_TIMEOUT_MS: "5000"
   ARIA2_POLL_MS: "1000"
 


### PR DESCRIPTION
Simplifies ARIA2_RPC_URL to http://aria2:6800/jsonrpc in dev ConfigMap.