### PR TITLE
chore(torrus): set dev ingress host

### DIFF
--- a/apps/torrus/overlays/dev/patch-ingress.yaml
+++ b/apps/torrus/overlays/dev/patch-ingress.yaml
@@ -4,7 +4,7 @@ metadata:
   name: torrus
 spec:
   rules:
-    - host: torrus.dev.xyz   # your dev host
+    - host: torrus.dev.jamaguchi.xyz   # your dev host
       http:
         paths:
           - path: /


### PR DESCRIPTION
Set dev Ingress host to torrus.dev.jamaguchi.xyz in patch-ingress.