### PR TITLE
chore(ingress-nginx): externalTrafficPolicy=Cluster via patch

### DIFF
--- a/infra/ingress-nginx-external-traffic-policy-patch.yaml
+++ b/infra/ingress-nginx-external-traffic-policy-patch.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: ingress-nginx-controller
+  namespace: ingress-nginx
+spec:
+  externalTrafficPolicy: Cluster

--- a/kustomization.yaml
+++ b/kustomization.yaml
@@ -1,3 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
 resources:
   - https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v1.12.3/deploy/static/provider/cloud/deploy.yaml
   - https://raw.githubusercontent.com/metallb/metallb/v0.15.2/config/manifests/metallb-native.yaml
@@ -7,3 +10,6 @@ resources:
   - plex/plex-deployment.yaml
   - it-tools/it-tools-deployment.yaml
   - flux-torrus-dev.yaml
+
+patchesStrategicMerge:
+  - infra/ingress-nginx-external-traffic-policy-patch.yaml


### PR DESCRIPTION
Add a strategic merge patch to set Service externalTrafficPolicy=Cluster for ingress-nginx-controller and include it in root kustomization.