### PR TITLE
chore(ingress-nginx): set static LB IP and include patch

### DIFF
--- a/infra/ingress-nginx-lbip-patch.yaml
+++ b/infra/ingress-nginx-lbip-patch.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: ingress-nginx-controller
+  namespace: ingress-nginx
+spec:
+  loadBalancerIP: 192.168.0.110

--- a/kustomization.yaml
+++ b/kustomization.yaml
@@ -13,3 +13,4 @@ resources:
 
 patchesStrategicMerge:
   - infra/ingress-nginx-external-traffic-policy-patch.yaml
+  - infra/ingress-nginx-lbip-patch.yaml


### PR DESCRIPTION
Adds a strategic-merge patch to set ingress-nginx-controller Service loadBalancerIP=192.168.0.110 and updates root kustomization to include it.