### PR TITLE
refactor: move it-tools to apps/it-tools and clean up ingress references

### DIFF
--- a/apps/it-tools/base/deployment.yaml
+++ b/apps/it-tools/base/deployment.yaml
@@ -19,18 +19,5 @@ spec:
       - name: it-tools
         image: corentinth/it-tools:nightly
         ports:
-        - containerPort: 80
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: it-tools
-  namespace: default
-spec:
-  selector:
-    app: it-tools
-  ports:
-    - protocol: TCP
-      port: 8080
-      targetPort: 80
-
+          - name: http
+            containerPort: 8080

--- a/apps/it-tools/base/ingress.yaml
+++ b/apps/it-tools/base/ingress.yaml
@@ -10,10 +10,9 @@ spec:
     http:
       paths:
       - path: /
-        pathType: ImplementationSpecific
+        pathType: Prefix
         backend:
           service:
             name: it-tools
             port:
-              number: 8080
-
+              number: http

--- a/apps/it-tools/base/service.yaml
+++ b/apps/it-tools/base/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: it-tools
+  namespace: default
+spec:
+  selector:
+    app: it-tools
+  ports:
+    - name: http
+      port: 80
+      targetPort: http
+

--- a/infra/ingress-nginx-external-traffic-policy-patch.yaml
+++ b/infra/ingress-nginx-external-traffic-policy-patch.yaml
@@ -1,7 +1,0 @@
-apiVersion: v1
-kind: Service
-metadata:
-  name: ingress-nginx-controller
-  namespace: ingress-nginx
-spec:
-  externalTrafficPolicy: Cluster

--- a/infra/ingress-nginx-lbip-patch.yaml
+++ b/infra/ingress-nginx-lbip-patch.yaml
@@ -3,5 +3,23 @@ kind: Service
 metadata:
   name: ingress-nginx-controller
   namespace: ingress-nginx
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/instance: ingress-nginx
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
 spec:
+  type: LoadBalancer
+  externalTrafficPolicy: Cluster
   loadBalancerIP: 192.168.0.110
+  selector:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/instance: ingress-nginx
+    app.kubernetes.io/name: ingress-nginx
+  ports:
+    - name: http
+      port: 80
+      targetPort: http
+    - name: https
+      port: 443
+      targetPort: https

--- a/kustomization.yaml
+++ b/kustomization.yaml
@@ -5,12 +5,12 @@ resources:
   - https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v1.12.3/deploy/static/provider/cloud/deploy.yaml
   - https://raw.githubusercontent.com/metallb/metallb/v0.15.2/config/manifests/metallb-native.yaml
   - infra/metallb-config.yaml
-  - infra/ingress-nginx.yaml
   - plex/plex-configmap.yaml
   - plex/plex-deployment.yaml
-  - it-tools/it-tools-deployment.yaml
+  - apps/it-tools/base/deployment.yaml
+  - apps/it-tools/base/service.yaml
+  - apps/it-tools/base/ingress.yaml
   - flux-torrus-dev.yaml
 
 patchesStrategicMerge:
-  - infra/ingress-nginx-external-traffic-policy-patch.yaml
   - infra/ingress-nginx-lbip-patch.yaml


### PR DESCRIPTION
- Move it-tools manifests to apps/it-tools/base (Deployment, Service, Ingress)
- Update root kustomization to reference new it-tools paths
- Remove obsolete infra/ingress-nginx.yaml and external traffic policy patch
- Keep ingress-nginx Service patched via LB IP patch only