### PR TITLE
fix(it-tools): correct Ingress backend port

### DIFF
--- a/apps/it-tools/base/ingress.yaml
+++ b/apps/it-tools/base/ingress.yaml
@@ -15,4 +15,4 @@ spec:
           service:
             name: it-tools
             port:
-              number: http
+              name: http


### PR DESCRIPTION
Use named Service port 'http' instead of number for it-tools Ingress backend.