### PR TITLE
chore: it-tools Ingress rename and flux-system tidy

### DIFF
--- a/apps/it-tools/base/ingress.yaml
+++ b/apps/it-tools/base/ingress.yaml
@@ -1,7 +1,7 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: ingress
+  name: tools
   namespace: default
 spec:
   ingressClassName: nginx

--- a/flux-system/kustomization.yaml
+++ b/flux-system/kustomization.yaml
@@ -1,5 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- gotk-components.yaml
-- gotk-sync.yaml
+  - gotk-components.yaml
+  - gotk-sync.yaml


### PR DESCRIPTION
- Rename it-tools Ingress to 'tools' and ensure backend uses named port 'http'\n- Tidy flux-system/kustomization.yaml formatting (no functional change)