### PR TITLE
chore(torrus): use ingressClassName in base Ingress

### DIFF
--- a/apps/torrus/base/ingress.yaml
+++ b/apps/torrus/base/ingress.yaml
@@ -2,9 +2,8 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: torrus
-  annotations:
-    kubernetes.io/ingress.class: nginx
 spec:
+  ingressClassName: nginx
   rules:
     - host: torrus.dev.jamaguchi.xyz   # patched per env in overlays
       http:


### PR DESCRIPTION
Replace deprecated kubernetes.io/ingress.class annotation with spec.ingressClassName: nginx.\n\nNote: prod overlay currently inherits dev host from base; recommend adding a prod patch to set the correct prod host (or make base host placeholder). Let me know the desired prod host and I can patch it.