### PR TITLE
chore(flux): tools dependsOn flux-system

### DIFF
--- a/flux-tools.yaml
+++ b/flux-tools.yaml
@@ -9,7 +9,7 @@ spec:
   prune: true
   wait: true
   dependsOn:
-    - name: homelab-kustomization
+    - name: flux-system
   sourceRef:
     kind: GitRepository
     name: flux-system


### PR DESCRIPTION
Fix dependsOn reference by pointing to existing Kustomization 'flux-system'.