### PR TITLE
chore(metallb): advertise on eno1 and wlp1s0

### DIFF
--- a/infra/metallb-config.yaml
+++ b/infra/metallb-config.yaml
@@ -17,3 +17,6 @@ metadata:
 spec:
   ipAddressPools:
   - default
+  interfaces:
+  - eno1
+  - wlp1s0


### PR DESCRIPTION
Add interfaces list to L2Advertisement to limit ARP to eno1 and wlp1s0.