### PR TITLE
chore(metallb): restrict L2Advertisement to node mugiwara and interface eno1

### DIFF
--- a/infra/metallb-config.yaml
+++ b/infra/metallb-config.yaml
@@ -16,7 +16,9 @@ metadata:
   namespace: metallb-system
 spec:
   ipAddressPools:
-  - default
+    - default
   interfaces:
-  - eno1
-  - wlp1s0
+    - eno1
+  nodeSelectors:
+    - matchLabels:
+        kubernetes.io/hostname: mugiwara


### PR DESCRIPTION
Adds nodeSelector for kubernetes.io/hostname=mugiwara and limits interfaces to eno1.