### PR TITLE
chore(metallb): enable speaker hostNetwork+debug via patch

### DIFF
--- a/infra/metallb-speaker-patch.yaml
+++ b/infra/metallb-speaker-patch.yaml
@@ -1,0 +1,15 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: speaker
+  namespace: metallb-system
+spec:
+  template:
+    spec:
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+      containers:
+        - name: speaker
+          args:
+            - --port=7472
+            - --log-level=debug

--- a/kustomization.yaml
+++ b/kustomization.yaml
@@ -12,3 +12,4 @@ resources:
 
 patchesStrategicMerge:
   - infra/ingress-nginx-service-patch.yaml
+  - infra/metallb-speaker-patch.yaml


### PR DESCRIPTION
Add strategic-merge patch to set hostNetwork and --log-level=debug on MetalLB speaker for better ARP visibility.