### PR TITLE
fix(ingress-nginx): set externalTrafficPolicy=Local

### DIFF
--- a/infra/ingress-nginx-service-patch.yaml
+++ b/infra/ingress-nginx-service-patch.yaml
@@ -5,5 +5,5 @@ metadata:
   namespace: ingress-nginx
 spec:
   type: LoadBalancer
-  externalTrafficPolicy: Cluster
+  externalTrafficPolicy: Local
   loadBalancerIP: 192.168.0.110


### PR DESCRIPTION
Change ingress-nginx-controller Service to Local to avoid hairpin and ensure VIP traffic terminates on nodes with endpoints.