### PR TITLE
fix(torrus): correct dev Ingress /v1 path and port name

### DIFF
--- a/apps/torrus/base/ingress.yaml
+++ b/apps/torrus/base/ingress.yaml
@@ -5,20 +5,13 @@ metadata:
 spec:
   ingressClassName: nginx
   rules:
-  - host: torrus.dev.jamaguchi.xyz
-    http:
-      paths:
-        - path: /
-          pathType: Prefix
-          backend:
-            service:
-              name: torrus
-              port:
-                number: 80
-        - path: /v1
-          pathType: Prefix
-          backend:
-            service:
-              name: torrus
-              port:
-                number: 80
+    - host: torrus.dev.jamaguchi.xyz   # patched per env in overlays
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: torrus
+                port:
+                  name: http

--- a/apps/torrus/overlays/dev/patch-ingress.yaml
+++ b/apps/torrus/overlays/dev/patch-ingress.yaml
@@ -7,6 +7,13 @@ spec:
     - host: torrus.dev.jamaguchi.xyz   # your dev host
       http:
         paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: torrus
+                port:
+                  number: 80
           - path: /v1
             pathType: Prefix
             backend:


### PR DESCRIPTION
Move /v1 path definition to dev overlay and use named service port http.