### PR TITLE
chore(torrus): trigger rollout with nonce annotation

### DIFF
--- a/apps/torrus/base/deployment.yaml
+++ b/apps/torrus/base/deployment.yaml
@@ -10,6 +10,8 @@ spec:
       app: torrus
   template:
     metadata:
+      annotations:
+        rollout/nonce: "2025-09-07T00:00:00Z"
       labels:
         app: torrus
     spec:


### PR DESCRIPTION
Adds rollout/nonce annotation in the Torrus base deployment template to force a new rollout. This is a safe no-op change that triggers pods to restart without altering runtime behavior.

- File: apps/torrus/base/deployment.yaml
- Change: add metadata.annotations["rollout/nonce"]