### PR TITLE
chore(torrus): bump rollout nonce

### DIFF
--- a/apps/torrus/base/deployment.yaml
+++ b/apps/torrus/base/deployment.yaml
@@ -11,7 +11,7 @@ spec:
   template:
     metadata:
       annotations:
-        rollout/nonce: "2025-09-07T00:00:00Z"
+        rollout/nonce: "2025-09-07T15:00:00Z"
       labels:
         app: torrus
     spec:


### PR DESCRIPTION
Bumps the rollout/nonce annotation in the Torrus base deployment to force a new rollout.

- File: apps/torrus/base/deployment.yaml
- Change: update metadata.annotations["rollout/nonce"] value