### PR TITLE
fix(postgres): drop duplicate namespace resource from torrus-dev overlay

### DIFF
--- a/apps/postgres/overlays/torrus-dev/kustomization.yaml
+++ b/apps/postgres/overlays/torrus-dev/kustomization.yaml
@@ -3,7 +3,6 @@ kind: Kustomization
 namespace: torrus-dev
 resources:
   - ../../base
-  - namespace.yaml
   - secret-app-creds.yaml
 patches:
   - path: patch-statefulset.yaml

--- a/apps/postgres/overlays/torrus-dev/namespace.yaml
+++ b/apps/postgres/overlays/torrus-dev/namespace.yaml
@@ -1,4 +1,0 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: torrus-dev


### PR DESCRIPTION
fix(postgres): drop duplicate namespace resource from torrus-dev overlay