### PR TITLE
fix: deduplicate torrus-dev Namespace by centralizing under cluster apps; remove namespace.yaml from torrus and postgres overlays

### DIFF
--- a/apps/postgres/overlays/torrus-dev/namespace.yaml
+++ b/apps/postgres/overlays/torrus-dev/namespace.yaml
@@ -1,4 +1,0 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: torrus-dev

--- a/apps/torrus/overlays/dev/namespace.yaml
+++ b/apps/torrus/overlays/dev/namespace.yaml
@@ -1,4 +1,0 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: torrus-dev


### PR DESCRIPTION
fix: deduplicate torrus-dev Namespace by centralizing under cluster apps; remove namespace.yaml from torrus and postgres overlays