### PR TITLE
postgres/torrus-dev: add accessModes and storageClassName to PVC template

### DIFF
--- a/apps/postgres/overlays/torrus-dev/patch-statefulset.yaml
+++ b/apps/postgres/overlays/torrus-dev/patch-statefulset.yaml
@@ -33,6 +33,9 @@ spec:
     - metadata:
         name: data
       spec:
+        accessModes:
+          - ReadWriteOnce
+        storageClassName: local-path
         resources:
           requests:
             storage: 10Gi


### PR DESCRIPTION
postgres/torrus-dev: add accessModes and storageClassName to PVC template