### PR TITLE
fix(postgres): robust env expansion in init DO block

### DIFF
--- a/apps/postgres/base/init/10-create-app-user.sh
+++ b/apps/postgres/base/init/10-create-app-user.sh
@@ -8,14 +8,21 @@ set -e
 
 echo "Ensuring app role and database exist: $APP_DB / $APP_USER"
 
-# Ensure role exists and set password (must be done outside a transaction-safe block for CREATE DATABASE later)
-psql -v ON_ERROR_STOP=1 --username "postgres" <<-'SQL'
+# Ensure role exists and set password.
+# Use psql variables to safely inject env values while keeping DO $$ intact.
+psql -v ON_ERROR_STOP=1 \
+     -v APP_USER="${APP_USER}" \
+     -v APP_PASSWORD="${APP_PASSWORD}" \
+     --username "postgres" <<-'SQL'
   DO $$
+  DECLARE
+    v_user text := :'APP_USER';
+    v_pass text := :'APP_PASSWORD';
   BEGIN
-    IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = '${APP_USER}') THEN
-      EXECUTE format('CREATE USER %I WITH PASSWORD %L', '${APP_USER}', '${APP_PASSWORD}');
+    IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = v_user) THEN
+      EXECUTE format('CREATE USER %I WITH PASSWORD %L', v_user, v_pass);
     ELSE
-      EXECUTE format('ALTER USER %I WITH PASSWORD %L', '${APP_USER}', '${APP_PASSWORD}');
+      EXECUTE format('ALTER USER %I WITH PASSWORD %L', v_user, v_pass);
     END IF;
   END
   $$;


### PR DESCRIPTION
- Use psql -v to pass APP_USER/APP_PASSWORD and reference them as :'VAR' inside DO\n- Prevents shell from expanding 9248 and ensures correct role name\n- DB creation remains outside DO (as before)\n\nThis corrects prior run that created a literal "" role.