### PR TITLE
fix(postgres): ensure app user owns DB and can CREATE in public schema

### DIFF
--- a/apps/postgres/base/init/10-create-app-user.sh
+++ b/apps/postgres/base/init/10-create-app-user.sh
@@ -20,5 +20,10 @@ if ! psql -tA --username "postgres" -c "SELECT 1 FROM pg_database WHERE datname 
   psql --username "postgres" -c "CREATE DATABASE \"${APP_DB}\""
 fi
 
-# Grant privileges
+# Ownership and schema privileges so the app can create tables in public
+psql --username "postgres" -c "ALTER DATABASE \"${APP_DB}\" OWNER TO \"${APP_USER}\""
+psql --username "postgres" -d "${APP_DB}" -c "ALTER SCHEMA public OWNER TO \"${APP_USER}\""
+psql --username "postgres" -d "${APP_DB}" -c "GRANT USAGE, CREATE ON SCHEMA public TO \"${APP_USER}\""
+
+# Grant database-level privileges (CONNECT, CREATE, TEMP)
 psql --username "postgres" -c "GRANT ALL PRIVILEGES ON DATABASE \"${APP_DB}\" TO \"${APP_USER}\""


### PR DESCRIPTION
- After creating/ensuring user & DB, set DB owner to app user\n- Set public schema owner and grant USAGE, CREATE to app user\n- Keep DB creation outside transaction\n- Retain database-level GRANTs\n\nThis prevents 'permission denied for schema public' during app migrations.