### PR TITLE
pgAdmin: add Deployment/Service/Ingress (torrus-dev)

### DIFF
--- a/apps/pgadmin/base/deployment.yaml
+++ b/apps/pgadmin/base/deployment.yaml
@@ -1,0 +1,27 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pgadmin
+  labels:
+    app: pgadmin
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: pgadmin
+  template:
+    metadata:
+      labels:
+        app: pgadmin
+    spec:
+      containers:
+        - name: pgadmin
+          image: dpage/pgadmin4:8.12
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 80
+          envFrom:
+            - secretRef:
+                name: pgadmin-credentials
+

--- a/apps/pgadmin/base/ingress.yaml
+++ b/apps/pgadmin/base/ingress.yaml
@@ -1,0 +1,18 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: pgadmin
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: pgadmin.dev.jamaguchi.xyz   # patched per env in overlays
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: pgadmin
+                port:
+                  name: http
+

--- a/apps/pgadmin/base/kustomization.yaml
+++ b/apps/pgadmin/base/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - deployment.yaml
+  - service.yaml
+  - ingress.yaml
+

--- a/apps/pgadmin/base/service.yaml
+++ b/apps/pgadmin/base/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: pgadmin
+  labels:
+    app: pgadmin
+spec:
+  selector:
+    app: pgadmin
+  ports:
+    - name: http
+      port: 80
+      targetPort: 80
+

--- a/apps/pgadmin/overlays/torrus-dev/kustomization.yaml
+++ b/apps/pgadmin/overlays/torrus-dev/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: torrus-dev
+resources:
+  - ../../base
+  - secret.yaml
+

--- a/apps/pgadmin/overlays/torrus-dev/secret.yaml
+++ b/apps/pgadmin/overlays/torrus-dev/secret.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: pgadmin-credentials
+type: Opaque
+stringData:
+  PGADMIN_DEFAULT_EMAIL: "you@example.com"
+  PGADMIN_DEFAULT_PASSWORD: "ChangeMePgAdmin"
+

--- a/clusters/mugiwara/apps/kustomization.yaml
+++ b/clusters/mugiwara/apps/kustomization.yaml
@@ -10,8 +10,8 @@ resources:
   - ../../../apps/it-tools/overlays/prod
   - ../../../apps/plex/overlays/prod
   - ../../../apps/postgres/overlays/torrus-dev
+  - ../../../apps/pgadmin/overlays/torrus-dev
 
 
 patchesStrategicMerge:
   - patch-ingress-nginx-service.yaml
-


### PR DESCRIPTION
- Adds apps/pgadmin with Deployment, Service, Ingress (nginx)\n- Host: pgadmin.dev.jamaguchi.xyz\n- Credentials via Secret in overlay (torrus-dev)\n- Wired into clusters/mugiwara/apps kustomization\n\nAccess via Ingress once Flux reconciles.