### PR TITLE
chore(pgadmin): set default email to torrus-dev@local

### DIFF
--- a/apps/pgadmin/overlays/torrus-dev/secret.yaml
+++ b/apps/pgadmin/overlays/torrus-dev/secret.yaml
@@ -4,6 +4,6 @@ metadata:
   name: pgadmin-credentials
 type: Opaque
 stringData:
-  PGADMIN_DEFAULT_EMAIL: "you@example.com"
+  PGADMIN_DEFAULT_EMAIL: "torrus-dev@local"
   PGADMIN_DEFAULT_PASSWORD: "ChangeMePgAdmin"
 


### PR DESCRIPTION
Update pgAdmin default login email to torrus-dev@local in torrus-dev overlay.