### PR TITLE
fix(pgadmin): valid default email (FQDN)

### DIFF
--- a/apps/pgadmin/overlays/torrus-dev/secret.yaml
+++ b/apps/pgadmin/overlays/torrus-dev/secret.yaml
@@ -4,6 +4,5 @@ metadata:
   name: pgadmin-credentials
 type: Opaque
 stringData:
-  PGADMIN_DEFAULT_EMAIL: "torrus-dev@local"
+  PGADMIN_DEFAULT_EMAIL: "torrus-dev@dev.jamaguchi.xyz"
   PGADMIN_DEFAULT_PASSWORD: "ChangeMePgAdmin"
-


### PR DESCRIPTION
Use torrus-dev@dev.jamaguchi.xyz as PGADMIN_DEFAULT_EMAIL to satisfy pgAdmin email validation.