### PR TITLE
feat(cloudflared): publish ingress via Cloudflare Tunnel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/infra/networking/cloudflared/manifests/secret.example.yaml

--- a/infra/kustomization.yaml
+++ b/infra/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - networking/cloudflared

--- a/infra/networking/cloudflared/README.md
+++ b/infra/networking/cloudflared/README.md
@@ -1,0 +1,34 @@
+# Cloudflare Tunnel for Cluster Ingress
+
+Publish existing Kubernetes ingress (nginx) to the public internet via Cloudflare Tunnel without opening router ports.
+
+## What this includes
+- Namespace `networking`
+- ConfigMap `cloudflared-config` with ingress hostname routing to the in-cluster nginx controller
+- Deployment `cloudflared` running in token mode and reading config from the ConfigMap
+- Root infra kustomization reference (see below)
+
+## Operator steps (one-time, outside Git)
+1. In Cloudflare Dashboard, add your domain if not already.
+2. Create a new Tunnel (Zero Trust → Access → Tunnels). Copy the Tunnel Token.
+3. In the Tunnel “Public Hostnames” section, add entries for each hostname (e.g., `n8n.jamaguchi.xyz`, `aria2.jamaguchi.xyz`). Target should be HTTP with URL pointing to your in-cluster nginx controller service (no TLS needed inside cluster). Cloudflare will create DNS records.
+4. Create the Kubernetes Secret in the cluster (or manage via SOPS/Flux):
+   ```bash
+   kubectl -n networking create secret generic cloudflared-secret \
+     --from-literal=TUNNEL_TOKEN='<paste-token-here>'
+   ```
+5. Apply/reconcile the manifests (e.g., via Flux). Verify the `cloudflared` Pod is Running.
+6. Test external access, e.g., `curl -I https://n8n.jamaguchi.xyz`.
+
+## Notes
+- Keep authentication/authorization at the application layer as appropriate.
+- For strict end-to-end TLS later, use Cloudflare Origin Certificates and change the `service:` URL(s) to `https://` with valid origin certs.
+- Contact: you@example.com
+
+## Files
+- `manifests/namespace.yaml`: creates `networking` namespace.
+- `manifests/configmap.yaml`: cloudflared config with public hostnames routing to nginx controller.
+- `manifests/deployment.yaml`: cloudflared token-run deployment.
+
+## Secret (not in Git)
+If you want a template example (not applied by GitOps), see `manifests/secret.example.yaml`.

--- a/infra/networking/cloudflared/kustomization.yaml
+++ b/infra/networking/cloudflared/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: networking
+resources:
+  - manifests/namespace.yaml
+  - manifests/configmap.yaml
+  - manifests/deployment.yaml

--- a/infra/networking/cloudflared/manifests/configmap.yaml
+++ b/infra/networking/cloudflared/manifests/configmap.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cloudflared-config
+  namespace: networking
+data:
+  config.yaml: |
+    # Cloudflared ingress mappings. Public hostnames → cluster ingress
+    ingress:
+      - hostname: n8n.jamaguchi.xyz
+        service: http://ingress-nginx-controller.ingress-nginx.svc.cluster.local:80
+      - hostname: aria2.jamaguchi.xyz
+        service: http://ingress-nginx-controller.ingress-nginx.svc.cluster.local:80
+      - service: http_status:404

--- a/infra/networking/cloudflared/manifests/deployment.yaml
+++ b/infra/networking/cloudflared/manifests/deployment.yaml
@@ -1,0 +1,40 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cloudflared
+  namespace: networking
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: cloudflared
+  template:
+    metadata:
+      labels:
+        app: cloudflared
+    spec:
+      containers:
+        - name: cloudflared
+          image: cloudflare/cloudflared:latest
+          args:
+            - tunnel
+            - --no-autoupdate
+            - run
+            - --token
+            - $(TUNNEL_TOKEN)
+            - --config
+            - /etc/cloudflared/config.yaml
+          env:
+            - name: TUNNEL_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: cloudflared-secret
+                  key: TUNNEL_TOKEN
+          volumeMounts:
+            - name: cfg
+              mountPath: /etc/cloudflared/config.yaml
+              subPath: config.yaml
+      volumes:
+        - name: cfg
+          configMap:
+            name: cloudflared-config

--- a/infra/networking/cloudflared/manifests/namespace.yaml
+++ b/infra/networking/cloudflared/manifests/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: networking


### PR DESCRIPTION
Adds Cloudflare Tunnel deployment under infra/networking/cloudflared to expose in-cluster nginx ingress without router port-forwarding.\n\nIncluded:\n- Namespace: networking\n- ConfigMap: cloudflared-config mapping public hostnames to ingress-nginx controller service\n- Deployment: token-run mode consuming TUNNEL_TOKEN Secret\n- Root infra kustomization reference\n\nOperator steps:\n1) Create Tunnel + hostnames in Cloudflare Zero Trust, copy the token.\n2) Create Secret: kubectl -n networking create secret generic cloudflared-secret --from-literal=TUNNEL_TOKEN='<token>'.\n3) Reconcile and verify Pod Running.\n4) Test external access to hostnames.\n\nContact: you@example.com